### PR TITLE
gitlab-ci: Turn off ORT Advisor by default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -202,7 +202,7 @@ ort-scan:
     - export FAIL_ON_OUTDATED_NOTICE_FILE=${FAIL_ON_OUTDATED_NOTICE_FILE:-"false"}
     - export ORT_CONFIG_REVISION=${ORT_CONFIG_REVISION:-"main"}
     - export ORT_CONFIG_REPO_URL=${ORT_CONFIG_REPO_URL:-"https://github.com/oss-review-toolkit/ort-config.git"}
-    - export ORT_DISABLE_ADVISOR=${ORT_DISABLE_ADVISOR:-"false"}
+    - export ORT_DISABLE_ADVISOR=${ORT_DISABLE_ADVISOR:-"true"}
     - export ORT_DISABLE_EVALUATOR=${ORT_DISABLE_EVALUATOR:-"false"}
     - export ORT_DISABLE_SCANNER=${ORT_DISABLE_SCANNER:-"true"}
     - export ORT_LOG_LEVEL=${ORT_LOG_LEVEL:-"performance"}


### PR DESCRIPTION
As not all users might agree to terms and conditions of OSS Index.

Signed-off-by: Thomas Steenbergen <opensource@steenbe.nl>

