### PR TITLE
Rename the ORT env variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,7 +123,7 @@ ort-scan:
       - cache/ivy2/cache
       - cache/sbt
   variables:
-    ORT: "/opt/ort/bin/ort"
+    ORT_CLI: "/opt/ort/bin/ort"
 
     ORT_ADVISOR_PROVIDERS: "OssIndex"
 
@@ -223,7 +223,7 @@ ort-scan:
     - echo "export ORT_DISABLE_ADVISOR='${ORT_DISABLE_ADVISOR:-'false'}'" >> vars.env
     - echo "export ORT_DISABLE_EVALUATOR='${ORT_DISABLE_EVALUATOR:-'false'}'" >> vars.env
     - echo "export ORT_DISABLE_SCANNER='${ORT_DISABLE_SCANNER:-'false'}'" >> vars.env
-    - export ORT_VERSION=$($ORT --version)
+    - export ORT_VERSION=$($ORT_CLI --version)
     - echo "export ORT_VERSION='$ORT_VERSION'" >> vars.env
 
     - ./scripts/check-vars.sh
@@ -265,7 +265,7 @@ ort-scan:
     - |
       if [[ ! -z "$ORT_REVISION" ]]; then 
         ./scripts/setup-ort.sh 
-        export ORT="$CI_PROJECT_DIR/bin/ort"
+        export ORT_CLI="$CI_PROJECT_DIR/bin/ort"
         export ORTH="$CI_PROJECT_DIR/bin/orth"
       fi
 

--- a/scripts/ort-advisor.sh
+++ b/scripts/ort-advisor.sh
@@ -9,7 +9,7 @@ else
     ORT_RESULTS_INPUT_FILE=$ORT_RESULTS_SCANNER_FILE
 fi
 
-$ORT \
+$ORT_CLI \
     --$ORT_LOG_LEVEL \
     --stacktrace \
     advise \

--- a/scripts/ort-analyzer.sh
+++ b/scripts/ort-analyzer.sh
@@ -49,7 +49,7 @@ echo "------------------------------------------"
 echo "Running ORT analyzer..."
 echo "------------------------------------------"
 
-$ORT \
+$ORT_CLI \
     --$ORT_LOG_LEVEL \
     --stacktrace \
     $ORT_OPTIONS \

--- a/scripts/ort-downloader.sh
+++ b/scripts/ort-downloader.sh
@@ -9,7 +9,7 @@ echo "------------------------------------------"
 # Remove all special characters and whitespace from the PROJECT_NAME, because some tools cannot handle them.
 SAFE_SW_NAME=$(echo $SW_NAME | sed -e 's/[^A-Za-z0-9 \-\_]//g' -e 's/\s/_/g')
 
-$ORT \
+$ORT_CLI \
     --$ORT_LOG_LEVEL \
     --stacktrace \
     download \

--- a/scripts/ort-evaluator.sh
+++ b/scripts/ort-evaluator.sh
@@ -45,7 +45,7 @@ else
     echo "Error: ORT policy rules file (*.rules.kts) not found. Please set ORT_CONFIG_RULES_FILE"
 fi
 
-$ORT \
+$ORT_CLI \
     --$ORT_LOG_LEVEL \
     --stacktrace \
     evaluate \
@@ -61,7 +61,7 @@ if [ $EXIT_CODE -ge 2 ]; then
 fi
 
 # Upload the final ORT result to PostgreSQL.
-# $ORT \
+# $ORT_CLI \
 #     --$ORT_LOG_LEVEL \
 #     --stacktrace \
 #     -c $ORT_CLI_CONFIG_FILE \

--- a/scripts/ort-reporter.sh
+++ b/scripts/ort-reporter.sh
@@ -61,7 +61,7 @@ fi
 #    ORT_REPORTER_OPTIONS="$ORT_REPORTER_OPTIONS -O SpdxDocument=document.name='${SW_NAME}' \ -O SpdxDocument=output.file.formats=json,yaml"
 # fi
 
-$ORT \
+$ORT_CLI \
     --$ORT_LOG_LEVEL \
     --stacktrace \
     report \

--- a/scripts/ort-scanner.sh
+++ b/scripts/ort-scanner.sh
@@ -5,7 +5,7 @@
 export JAVA_OPTS="-Xmx24G"
 
 echo "Scan source code for packages defined as dependencies and store results in $ORT_RESULTS_DIR."
-$ORT \
+$ORT_CLI \
     --$ORT_LOG_LEVEL \
     --stacktrace \
     -c $ORT_CLI_CONFIG_FILE \


### PR DESCRIPTION
In order to avoid collisions in addEnvironmentSource() introduced in [1]

[1]: https://github.com/oss-review-toolkit/ort/pull/5195/commits/8096840c65a0d620825d3fb61c094386960a8f02

Signed-off-by: Andriy Zhernovskyi <ext-andriy.zhernovskyi@here.com>