### PR TITLE
CI: Improve configuration options

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,9 @@ variables:
   ORT_DISABLE_ADVISOR:
     value: ""
     description: "If set to 'true', ORT's advisor will not run (no security vulnerability checks)."
+  ORT_DISABLE_DOWNLOADER:
+    value: "false"
+    description: "If set to 'true', ORT's downloader will not run. For example, the repo might be cloned already if used in a pipeline. Set PROJECT_DIR accordingly to current dir if this is disabled."
   ORT_DISABLE_EVALUATOR:
     value: ""
     description: "If set to 'true', ORT's evaluator will not run (no policy checks)."
@@ -97,6 +100,10 @@ variables:
   ORT_USE_DEV_DB:
     value: "false"
     description: "Set to 'true' to download/upload scanned results from/to development database."
+  PROJECT_DIR:
+    value: "project"
+    description: |
+      "The project download dir." 
   RUNNER_TAG:
     value: docker
     description: |
@@ -155,8 +162,6 @@ ort-scan:
     ORT_HOW_TO_FIX_TEXT_PROVIDER_FILE: "${ORT_CONFIG_DIR}/how-to-fix-text-provider.kts"
 
     ORT_REPORT_FORMATS: "CycloneDx,EvaluatedModel,GitLabLicenseModel,NoticeTemplate,SpdxDocument,StaticHtml,WebApp"
-
-    PROJECT_DIR: "project"
 
     ORT_RESULTS_DIR: "ort-results"
     ORT_RESULTS_ADVISOR_FILE: "${ORT_RESULTS_DIR}/advisor-result.json"
@@ -262,7 +267,11 @@ ort-scan:
     - echo "export ORT_CONFIG_REVISION='$ORT_CONFIG_REVISION'" >> vars.env
 
     # Execute ORT's Downloader to fetch the source code for the project to be scanned.
-    - ./scripts/ort-downloader.sh || { [ $? -eq 1 ] && exit 1; }
+
+    - |
+      if [[ "$ORT_DISABLE_DOWNLOADER" = "false" ]]; then
+        ./scripts/ort-downloader.sh || { [ $? -eq 1 ] && exit 1; }
+      fi
 
     - echo "[DEBUG] env vars"; env
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -107,7 +107,7 @@ variables:
   RUNNER_TAG:
     value: docker
     description: |
-      "Runner tag for the gitlab runner, defaults to 'docker'"
+      "Runner tag for the GitLab runner, defaults to 'docker'."
   REBUILD_DOCKER_IMAGE: 
     value: "false" 
     description: "Set value to 'true' in order to rebuild the Docker image."

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -97,6 +97,10 @@ variables:
   ORT_USE_DEV_DB:
     value: "false"
     description: "Set to 'true' to download/upload scanned results from/to development database."
+  RUNNER_TAG:
+    value: docker
+    description: |
+      "Runner tag for the gitlab runner, defaults to 'docker'"
   REBUILD_DOCKER_IMAGE: 
     value: "false" 
     description: "Set value to 'true' in order to rebuild the Docker image."
@@ -110,7 +114,7 @@ ort-scan:
     name: "$ORT_DOCKER_IMAGE"
     entrypoint: [""]
   tags:
-    - docker
+    - "$RUNNER_TAG"
   cache:
     key: "${CI_PROJECT_ID}"
     paths:

--- a/scripts/ort-advisor.sh
+++ b/scripts/ort-advisor.sh
@@ -13,7 +13,7 @@ $ORT_CLI \
     --$ORT_LOG_LEVEL \
     --stacktrace \
     advise \
-    -a $ORT_ADVISOR_PROVIDERS
+    -a $ORT_ADVISOR_PROVIDERS \
     -i $ORT_RESULTS_INPUT_FILE \
     -o $ORT_RESULTS_DIR \
     -f JSON


### PR DESCRIPTION
This minor PR improves configuration options we discovered we needed when testing this, and I think could be useful for others, in what should be a fully backwards compatible way (the defaults values are the same as the current ci template):

- Makes the runner tag configurable by making it a var (default: docker) (for example, we would use other runner tags then docker, like k8s etc)
- Makes the downloader optional (default: enabled). This allows the user optionally use the default checkout of gitlab etc instead, as would be the use case if including it in a pipe etc NOTE: As GitLab does not allows naming the default checkout dir fully yet (the option ci_builds_dir  for runners is not enabled by default, see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/4203, one might to need to change the project dir var when using this, as the user might not be able to set it to the default 'project'.
- advisor script failed in our runtime image due to a missing bash newline in the script, fixed