### PR TITLE
gitlab-ci: fixup evaluator results file with advisor results

### DIFF
--- a/scripts/ort-evaluator.sh
+++ b/scripts/ort-evaluator.sh
@@ -4,9 +4,11 @@
 # against customizable policy rules.
 
 if [[ "$ORT_DISABLE_SCANNER" = "true" ]]; then
-    ORT_RESULTS_INPUT_FILE=$ORT_RESULTS_ANALYZER_FILE
-elif [[ "$ORT_DISABLE_ADVISOR" = "false" ]]; then
-    ORT_RESULTS_INPUT_FILE=$ORT_RESULTS_ADVISOR_FILE
+    if [[ "$ORT_DISABLE_ADVISOR" = "true" ]]; then
+        ORT_RESULTS_INPUT_FILE=$ORT_RESULTS_ANALYZER_FILE
+    else
+        ORT_RESULTS_INPUT_FILE=$ORT_RESULTS_ADVISOR_FILE
+    fi
 else
     ORT_RESULTS_INPUT_FILE=$ORT_RESULTS_SCANNER_FILE
 fi


### PR DESCRIPTION
Evaluator should use the advisor results although the scanner is deactivated

Signed-off-by: Jürgen Wischer <33184634+unclejay80@users.noreply.github.com>

Please ensure that your pull request adheres to our [contribution guidelines](https://github.com/oss-review-toolkit/.github/blob/main/CONTRIBUTING.md). Thank you!
