### PR TITLE
feat(ort-scan): Broaden the ScanCode version range a bit

### DIFF
--- a/templates/ort-scan.yml
+++ b/templates/ort-scan.yml
@@ -192,6 +192,12 @@
                 password: "${POSTGRES_PASSWORD}"
                 sslmode: "disable"
                 parallelTransactions: 5
+          options:
+            ScanCode:
+              commandLine: "--copyright --license --info --strip-root --timeout 300"
+              parseLicenseExpressions: "true"
+              minVersion: "31.0.0"
+              maxVersion: "33.0.0"
           storages:
             postgres:
               connection:


### PR DESCRIPTION
Increase the cache hit frequency a bit by not requiring exact version matches. While at it, make some other default ScanCode options explicit, in order to avoid these being changed unnoticed.
