### PR TITLE
chore(ort-scan): Use ORT's new official (extended) docker image

### DIFF
--- a/templates/ort-scan.yml
+++ b/templates/ort-scan.yml
@@ -32,7 +32,7 @@
       - cache/ivy2/cache
       - cache/sbt
   variables:
-    ORT_DOCKER_IMAGE: "ghcr.io/alliander-opensource/ort-container:latest"
+    ORT_DOCKER_IMAGE: "ghcr.io/oss-review-toolkit/ort-extended:latest"
     ORT_RESULTS_PATH: "${CI_PROJECT_DIR}/ort-results"
 
     # GitLab will not cache things (see https://gitlab.com/gitlab-org/gitlab/-/issues/14151) outside the build's working


### PR DESCRIPTION
As ORT recently started to publish docker images on its own, start making use of it. Use the new docker instead of the legacy one, even though the legacy one may have had more testing.
