### PR TITLE
chore(ort-scan): Use ort image instead of ort-extended as default

### DIFF
--- a/templates/ort-scan.yml
+++ b/templates/ort-scan.yml
@@ -32,7 +32,7 @@
       - cache/ivy2/cache
       - cache/sbt
   variables:
-    ORT_DOCKER_IMAGE: "ghcr.io/oss-review-toolkit/ort-extended:latest"
+    ORT_DOCKER_IMAGE: "ghcr.io/oss-review-toolkit/ort:latest"
     ORT_RESULTS_PATH: "${CI_PROJECT_DIR}/ort-results"
 
     # GitLab will not cache things (see https://gitlab.com/gitlab-org/gitlab/-/issues/14151) outside the build's working


### PR DESCRIPTION
Changing the `ORT_DOCKER_IMAGE` variable to use the `ort` image, instead of the `ort-extended` because most of the projects are using languages that are in the `ort` image (Java, Python, NodeJS, Rust, Ruby and Golang) and not from the `ort-extended` (Android, iOS, Haskell).

Because this pipeline template is used in Java/Python/NodeJS projects, it is breaking the pipelines because of not found package managers.

Please refer to: https://ort-talk.slack.com/archives/C9NNJ54B1/p1695977688303359