### PR TITLE
chore: Upgrade ORT to the latest version

### DIFF
--- a/templates/ort-scan.yml
+++ b/templates/ort-scan.yml
@@ -32,7 +32,7 @@
       - cache/ivy2/cache
       - cache/sbt
   variables:
-    ORT_DOCKER_IMAGE: "ghcr.io/oss-review-toolkit/ort-extended:latest"
+    ORT_DOCKER_IMAGE: "ghcr.io/oss-review-toolkit/ort:6.1.1"
     ORT_RESULTS_PATH: "${CI_PROJECT_DIR}/ort-results"
 
     # GitLab will not cache things (see https://gitlab.com/gitlab-org/gitlab/-/issues/14151) outside the build's working


### PR DESCRIPTION
Note that with this release the image has been renamed from `ort-extended` to just `ort`. While at it, stop using the `latest` tag to avoid that things break.


