### PR TITLE
chore(ort-scan): Use renamed ORT Docker image

### DIFF
--- a/templates/ort-scan.yml
+++ b/templates/ort-scan.yml
@@ -32,7 +32,7 @@
       - cache/ivy2/cache
       - cache/sbt
   variables:
-    ORT_DOCKER_IMAGE: "ghcr.io/oss-review-toolkit/ort-extended:latest"
+    ORT_DOCKER_IMAGE: "ghcr.io/oss-review-toolkit/ort:latest"
     ORT_RESULTS_PATH: "${CI_PROJECT_DIR}/ort-results"
 
     # GitLab will not cache things (see https://gitlab.com/gitlab-org/gitlab/-/issues/14151) outside the build's working


### PR DESCRIPTION
The 'ort-extended' Docker image was renamed to just 'ort' in [1].

[1]: https://github.com/oss-review-toolkit/ort/commit/cd323ab55b660edf66d289ff91027afcb4a9723d

