### PR TITLE
chore(ort-scan)!: Enable all `.ort.yml` entries by default

### DIFF
--- a/templates/ort-scan.yml
+++ b/templates/ort-scan.yml
@@ -167,6 +167,8 @@
       echo -e "\e[1;33m Generating a 'config.yml' with a PostgreSQL storage..."
       cat << EOF > ${ORT_CONFIG_PATH}/config.yml
       ort:
+        enableRepositoryPackageConfigurations: true
+        enableRepositoryPackageCurations: true
         packageCurationProviders:
           - type: DefaultFile
           - type: DefaultDir


### PR DESCRIPTION
One reason for auto-generating a `config.yml` is to enable user to quickly try out ORT on CI. Enable package curations and configurations by default, so that users can also quickly try out using them from within the `.ort.yml` files.

