### PR TITLE
fix(ort-scan): Run Evaluator after Advisor

### DIFF
--- a/templates/ort-scan.yml
+++ b/templates/ort-scan.yml
@@ -355,31 +355,6 @@
         [[ ${ORT_CLI_SCANNER_EXIT_CODE} -eq 1 ]] && exit 1
       fi
 
-    # Run ORT's Evaluator to evaluate custom policy rules along with custom license classifications against the data gathered
-    # in preceding ORT stages and returns a list of policy violations (e.g. flags license or vulnerability findings).
-    - |
-      if [[ ${ORT_RUN_COMMANDS} == *"evaluator"* ]]; then
-        echo -e "\e[1;33m Running ORT Evaluator... "
-
-        ${ORT_CLI} \
-        --${ORT_LOG_LEVEL} \
-        ${ORT_CLI_ARGS} \
-        evaluate \
-        -i ${ORT_RESULTS_CURRENT_PATH} \
-        -o ${ORT_RESULTS_PATH} \
-        -f JSON \
-        ${ORT_CLI_EVALUATE_ARGS} \
-          || ORT_CLI_EVALUATE_EXIT_CODE=$? \
-          && export ORT_CLI_EVALUATE_EXIT_CODE="${ORT_CLI_EVALUATE_EXIT_CODE:-0}" \
-          && printenv >> vars.env
-
-        [[ -f ${ORT_RESULTS_EVALUATOR_PATH} ]] \
-          && ln -frs $ORT_RESULTS_EVALUATOR_PATH $ORT_RESULTS_CURRENT_PATH \
-          || echo -e "\e[1;31m File $ORT_RESULTS_EVALUATOR_PATH not found."
-
-        [[ ${ORT_CLI_EVALUATE_EXIT_CODE} -eq 1 ]] && exit 1
-      fi
-
     # Run ORT's Advisor to retrieve security advisories for used dependencies from configured vulnerability data services.
     - |
       if [[ ${ORT_RUN_COMMANDS} == *"advisor"* ]]; then
@@ -403,6 +378,31 @@
           || echo -e "\e[1;31m File $ORT_RESULTS_ADVISOR_PATH not found."
 
         [[ ${ORT_CLI_ADVISE_EXIT_CODE} -eq 1 ]] && exit 1
+      fi
+
+    # Run ORT's Evaluator to evaluate custom policy rules along with custom license classifications against the data gathered
+    # in preceding ORT stages and returns a list of policy violations (e.g. flags license or vulnerability findings).
+    - |
+      if [[ ${ORT_RUN_COMMANDS} == *"evaluator"* ]]; then
+        echo -e "\e[1;33m Running ORT Evaluator... "
+
+        ${ORT_CLI} \
+        --${ORT_LOG_LEVEL} \
+        ${ORT_CLI_ARGS} \
+        evaluate \
+        -i ${ORT_RESULTS_CURRENT_PATH} \
+        -o ${ORT_RESULTS_PATH} \
+        -f JSON \
+        ${ORT_CLI_EVALUATE_ARGS} \
+          || ORT_CLI_EVALUATE_EXIT_CODE=$? \
+          && export ORT_CLI_EVALUATE_EXIT_CODE="${ORT_CLI_EVALUATE_EXIT_CODE:-0}" \
+          && printenv >> vars.env
+
+        [[ -f ${ORT_RESULTS_EVALUATOR_PATH} ]] \
+          && ln -frs $ORT_RESULTS_EVALUATOR_PATH $ORT_RESULTS_CURRENT_PATH \
+          || echo -e "\e[1;31m File $ORT_RESULTS_EVALUATOR_PATH not found."
+
+        [[ ${ORT_CLI_EVALUATE_EXIT_CODE} -eq 1 ]] && exit 1
       fi
 
     # Run ORT's Reporter to present scan results in various formats such as visual reports,


### PR DESCRIPTION
Policy rules for security vulnerabilities do not work as expected prior to this change as the Evaluator is executed before the Advisor e.g. rules are checked before known vulnerabilities for packages are retrieved.

