### PR TITLE
fix: conditional if file `config.yml` is existing

### DIFF
--- a/templates/ort-scan.yml
+++ b/templates/ort-scan.yml
@@ -277,7 +277,7 @@
         ORT_CLI_ANALYZE_ARGS="--repository-configuration-file ${ORT_YML_PATH} ${ORT_CLI_ANALYZE_ARGS}"
         ORT_CLI_EVALUATE_ARGS="--repository-configuration-file ${ORT_YML_PATH} ${ORT_CLI_EVALUATE_ARGS}"
         ORT_CLI_REPORT_ARGS="--repository-configuration-file ${ORT_YML_PATH} ${ORT_CLI_REPORT_ARGS}"
-      elif [[ ! -z "${ORT_YML_PATH}" ]]; then
+      elif [[ ! -a "${ORT_YML_PATH}" ]]; then
         echo -e "\e[1;31m File ${ORT_YML_PATH} not found!."
       fi
 

--- a/templates/ort-scan.yml
+++ b/templates/ort-scan.yml
@@ -165,7 +165,7 @@
 
     # Generate ORT global configuration if not found and PostgreSQL is used.
     - |
-      if [[ (! -z "${ORT_CONFIG_PATH}/config.yml") && (-n "${POSTGRES_URL}") ]]; then
+      if [[ (! -a "${ORT_CONFIG_PATH}/config.yml") && (-n "${POSTGRES_URL}") ]]; then
       echo -e "\e[1;33m Generating a 'config.yml' with a PostgreSQL storage..."
       cat << EOF > ${ORT_CONFIG_PATH}/config.yml
       ort:
@@ -237,7 +237,7 @@
         severeIssueThreshold: "ERROR"
         severeRuleViolationThreshold: "ERROR"
       EOF
-      elif [[ ! -z "${ORT_CONFIG_PATH}/config.yml" ]]; then
+      elif [[ ! -a "${ORT_CONFIG_PATH}/config.yml" ]]; then
       echo -e "\e[1;33m Generating a 'config.yml' without a PostgreSQL storage..."
       cat << EOF > ${ORT_CONFIG_PATH}/config.yml
       ort:


### PR DESCRIPTION
The existing check is always going to be true. See this snippet

```
if [[ ! -z "${ORT_CONFIG_PATH}/config.yml" ]]; then
  echo "always true"
else
  echo "Using 'config.yml' from 'ort-config' repository..."
fi
```